### PR TITLE
Add package.json and package-lock.json files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "code",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,15 @@
 {
-  "name": "code",
+  "name": "active-directory-jenkins-plugin",
+  "version": "2.41.0",
   "lockfileVersion": 3,
   "requires": true,
-  "packages": {}
+  "packages": {
+    "": {
+      "name": "active-directory-jenkins-plugin",
+      "version": "2.41.0",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "devDependencies": {}
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "active-directory-jenkins-plugin",
+  "version": "2.41.0",
+  "description": "Jenkins Active Directory authentication plugin",
+  "main": "index.js",
+  "scripts": {
+    "install": "echo 'This is a Maven-based Jenkins plugin - use Maven commands'",
+    "build": "echo 'Run: mvn clean package'",
+    "test": "echo 'Run: mvn test'",
+    "serve": "echo 'Jenkins plugin development - use: mvn hpi:run'"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jenkinsci/active-directory-plugin"
+  },
+  "author": "Jenkins Community",
+  "license": "MIT",
+  "devDependencies": {}
+}


### PR DESCRIPTION
Add package.json and package-lock.json files to the project.

The package.json file includes:
- Project name: active-directory-jenkins-plugin
- Version: 2.41.0
- Description: Jenkins Active Directory authentication plugin
- Scripts that redirect to Maven commands for build, test, and serve operations
- Repository URL pointing to jenkinsci/active-directory-plugin
- MIT license
- Empty devDependencies object

The package-lock.json file includes:
- Lockfile version 3
- Project metadata matching package.json
- hasInstallScript flag set to true
- Empty packages configuration

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/c92575f3117046c6a82eb588f00bfbcc/vibe-garden)

👀 [Preview Link](https://c92575f3117046c6a82eb588f00bfbcc-vibe-garden.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>c92575f3117046c6a82eb588f00bfbcc</projectId>-->
<!--<branchName>vibe-garden</branchName>-->